### PR TITLE
add html lang attribute

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <base href="/kokori/" target="_blank">

--- a/flickr.html
+++ b/flickr.html
@@ -1,4 +1,5 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 
 <head>
     <title>kokori@flickr</title>


### PR DESCRIPTION
"If you are serving your page as XML (ie. using a MIM type such as application/xhtml+xml), you do not need the lang attribute. The xml:lang attribute alone will suffice."

As far as I can tell the `xml:lang` only matters if you are serving the html as xml, or in very old versions of html.

I can add it still if you'd like?

I also added the `<!DOCTYPE html>` tag to the flickr.html page as it wasn't there, but it was in the 404.html.
